### PR TITLE
Add parse size

### DIFF
--- a/include/webserv/config-parser/ConfigParser.hpp
+++ b/include/webserv/config-parser/ConfigParser.hpp
@@ -84,3 +84,5 @@ struct ListenData
 ListenData
 parseListen(const std::string& listenDirective);
 
+unsigned long long
+parseSize(const std::string& size);

--- a/include/webserv/config-parser/validator.hpp
+++ b/include/webserv/config-parser/validator.hpp
@@ -15,3 +15,6 @@ validateRoot(const std::string& value, std::string& errorMsg);
 
 bool
 validateListen(const std::string& value, std::string& errorMsg);
+
+bool
+validateSize(const std::string& value, std::string& errorMsg);

--- a/src/webserv/config-parser/ConfigParser.cpp
+++ b/src/webserv/config-parser/ConfigParser.cpp
@@ -21,7 +21,8 @@ static const ConfigItemCaracteristics knownConfigItems[] = {
     { "autoindex", validateAutoindex, ~0, NOT_A_BLOCK },
     { "file_upload", NULL, ~0, NOT_A_BLOCK },
     { "server_name", NULL, BLOCK_SERVER, NOT_A_BLOCK },
-    { "client_body_maxsize", NULL, BLOCK_SERVER, NOT_A_BLOCK },
+    { "client_body_maxsize", validateSize, BLOCK_SERVER, NOT_A_BLOCK },
+    { "upload_max_size", validateSize, ~0, NOT_A_BLOCK },
     { "default_error_file", NULL, BLOCK_GLOBAL, NOT_A_BLOCK },
 };
 

--- a/src/webserv/config-parser/parser.cpp
+++ b/src/webserv/config-parser/parser.cpp
@@ -1,5 +1,6 @@
 #include "utils/string.hpp"
 #include "webserv/config-parser/ConfigParser.hpp"
+#include <cmath>
 #include <sstream>
 
 /*
@@ -33,4 +34,30 @@ parseListen(const std::string& listenDirective)
     data.isDefault = w == "default_server";
 
     return data;
+}
+
+/*
+ * Returns the number of byte corresponding to the passed size expression.
+ * For example, "100kb" will return "100000".
+ */
+
+unsigned long long
+parseSize(const std::string& size)
+{
+    const char units[] = { 'k', 'm' };
+    std::istringstream iss(size);
+    unsigned long long n = 0;
+    std::string unit;
+
+    iss >> n >> unit;
+
+    for (unsigned i = 0; i != sizeof(units) / sizeof(*units); ++i) {
+        if (tolower(unit[0]) == units[i] &&
+            ((unit.size() == 2 && tolower(unit[1]) == 'b') ||
+             unit.size() == 1)) {
+            return n * (1 << (10 * (i + 1)));
+        }
+    }
+
+    return n;
 }

--- a/src/webserv/config-parser/validator.cpp
+++ b/src/webserv/config-parser/validator.cpp
@@ -125,3 +125,41 @@ validateListen(const std::string& value, std::string& errorMsg)
 
     return true;
 }
+
+bool
+validateSize(const std::string& value, std::string& errorMsg)
+{
+    const char units[] = { 'k', 'm' };
+    std::istringstream iss(value);
+    unsigned long long n;
+
+    if (!(iss >> n)) {
+        Formatter() << "Could not parse size \"" << value
+                    << "\": invalid integer part" >>
+          errorMsg;
+    }
+
+    std::string unit;
+    iss >> unit;
+
+    if (!unit.empty()) {
+        for (unsigned i = 0; i != sizeof(units) / sizeof(*units); ++i) {
+            for (unsigned i = 0; i != sizeof(units) / sizeof(*units); ++i) {
+                if (tolower(unit[0]) == units[i] &&
+                    ((unit.size() == 2 && tolower(unit[1]) == 'b') ||
+                     unit.size() == 1)) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    if (!unit.empty()) {
+        Formatter() << "Invalid unit \"" << unit
+                    << "\" Available units are: k[b],m[b]" >>
+          errorMsg;
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
Add `parseSize` function that parses sizes such as `12MB` `4KB` and returns the corresponding number of bytes.
Add parsing support for the `upload_max_size` directive.