### PR TITLE
Fix leaks when a parsing exception is thrown

### DIFF
--- a/include/webserv/config-parser/ConfigParser.hpp
+++ b/include/webserv/config-parser/ConfigParser.hpp
@@ -47,7 +47,8 @@ class ConfigParser
     */
 
     ConfigItem* makeConfigItem(std::pair<std::string, std::string> keyval,
-                               ConfigItem* contextItem);
+                               ConfigItem* contextItem,
+                               ConfigItem* const main);
 
   public:
     class ParserException : public std::runtime_error


### PR DESCRIPTION
Fix leaks that occurs if a `ConfigParser::ParserException` is thrown: the previously allocated config items are not automatically freed and the control flow is interrupted by the throw so there is no way to get the pointer to the global block config and free it recursively. This is fixed in this PR by manually deleting the main block before a `ParserException` is thrown.