### PR TITLE
Make split utility more flexible

### DIFF
--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 std::vector<std::string>
-split(const std::string& s, unsigned char c);
+split(const std::string& s, const std::string& set = "\t\n\r\v ");
 
 std::string
 trim(const std::string& s);

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -4,20 +4,48 @@
 #include <sstream>
 #include <string>
 
+/**
+ * @brief Helper method for working with split. Returns the index where any of the characters in set first occurs in s.
+ * 
+ * @param s The string to search in
+ * @param set A set of characters that are matchable
+ * @param pos The position to start the search at in s
+ * @return std::string::size_type the index where the first occurence of any character in set is found, std::string::npos is there is not.
+ */
+
+static std::string::size_type splitFindOneOfSet(const std::string& s, const std::string& set, std::string::size_type pos = 0)
+{
+    for (std::string::size_type i = pos; i != s.size(); ++i) {
+        if (set.find(s[i]) != std::string::npos) {
+            return i;
+        }
+    }
+
+    return std::string::npos;
+}
+
+/**
+ * @brief splits a std::string into one or several strings, each character of set being a possible delimiter.
+ * 
+ * @param s The string to split
+ * @param set A string which each of its characters can be a delimiter to split s
+ * @return std::vector<std::string>  A vector of string that holds the split.
+ */
+
 std::vector<std::string>
-split(const std::string& s, unsigned char c)
+split(const std::string& s, const std::string& set)
 {
     std::vector<std::string> v;
     std::string::size_type bpos = 0, fpos = 0;
 
     while (bpos < s.size()) {
-        while (s[bpos] == c) {
+        while (set.find(s[bpos]) != std::string::npos) {
             ++bpos;
         }
         if (bpos == s.size()) {
             break;
         }
-        fpos = s.find(c, bpos);
+        fpos = splitFindOneOfSet(s, set, bpos);
         if (fpos == std::string::npos) {
             fpos = s.size();
         }
@@ -78,7 +106,7 @@ expandVar(const std::string& path)
 bool
 isIPv4(const std::string& s)
 {
-    std::vector<std::string> ss = split(s, '.');
+    std::vector<std::string> ss = split(s, ".");
     std::istringstream iss;
 
     if (ss.size() != 4) {

--- a/src/webserv/config-parser/validator.cpp
+++ b/src/webserv/config-parser/validator.cpp
@@ -25,7 +25,7 @@ validateMethod(const std::string& value, std::string& errorMsg)
     bool seen[sizeof(availableMethods) / sizeof(char*)] = { false };
     size_t n = sizeof(availableMethods) / sizeof(char*);
 
-    std::vector<std::string> vs = split(value, ' ');
+    std::vector<std::string> vs = split(value);
 
     for (std::vector<std::string>::const_iterator ite = vs.begin();
          ite != vs.end();
@@ -55,7 +55,7 @@ validateMethod(const std::string& value, std::string& errorMsg)
 bool
 validateIndex(const std::string& value, std::string& errorMsg)
 {
-    std::vector<std::string> vs = split(value, ' ');
+    std::vector<std::string> vs = split(value);
     std::vector<std::string> seen;
 
     for (std::vector<std::string>::const_iterator ite = vs.begin();


### PR DESCRIPTION
`split` now has the following prototype: 
```cpp
std::vector<std::string> split(const std::string&s, const std::string& set = "\t\n\r\v ")
```
The `set` string holds a set of characters, each one being an individual separator. If unspecified, all spaces such as defined by `isspace(3)` are used as possible delimiters.